### PR TITLE
flac registration

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The ZikiChomgo Authors. All rights reserved.  Use of this source
+// Copyright 2018 The ZikiChombo Authors. All rights reserved.  Use of this source
 // code is governed by a license that can be found in the License file.
 
 // Package ext houses zc collaboration with external imports.

--- a/flac/decoder.go
+++ b/flac/decoder.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The ZikiChomgo Authors. All rights reserved.  Use of this source
+// Copyright 2018 The ZikiChombo Authors. All rights reserved.  Use of this source
 // code is governed by a license that can be found in the License file.
 
 // TODO: add seek support; only enabled in the dev branch of mewkiz/flac.

--- a/flac/decoder_test.go
+++ b/flac/decoder_test.go
@@ -3,7 +3,31 @@
 
 package flac
 
-import "zikichombo.org/sound"
+import (
+	"os"
+	"testing"
+
+	"zikichombo.org/codec"
+	"zikichombo.org/sio"
+	"zikichombo.org/sound"
+)
 
 // Assert that flac.Decoder implements the sound.Source interface.
 var _ sound.Source = (*Decoder)(nil)
+
+func TestRegister(t *testing.T) {
+	co, err := codec.CodecFor(".flac", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open("0.flac")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec, _, err := co.Decoder(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dec.Close()
+	sio.Play(dec)
+}

--- a/flac/decoder_test.go
+++ b/flac/decoder_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The ZikiChomgo Authors. All rights reserved.  Use of this source
+// Copyright 2018 The ZikiChombo Authors. All rights reserved.  Use of this source
 // code is governed by a license that can be found in the License file.
 
 package flac

--- a/flac/doc.go
+++ b/flac/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The ZikiChomgo Authors. All rights reserved.  Use of this source
+// Copyright 2018 The ZikiChombo Authors. All rights reserved.  Use of this source
 // code is governed by a license that can be found in the License file.
 
 // Package flac provides decoding of FLAC audio streams.

--- a/flac/register.go
+++ b/flac/register.go
@@ -1,0 +1,26 @@
+package flac
+
+import (
+	"io"
+
+	"zikichombo.org/codec"
+	"zikichombo.org/sound"
+	"zikichombo.org/sound/sample"
+)
+
+type flacCodec struct {
+	codec.NullCodec
+}
+
+func (f *flacCodec) Extensions() []string {
+	return []string{".flc", ".flac"}
+}
+
+func (f *flacCodec) Decoder(rc io.ReadCloser) (sound.Source, sample.Codec, error) {
+	dec, err := NewDecoder(rc)
+	return dec, codec.AnySampleCodec, err
+}
+
+func init() {
+	codec.RegisterCodec(&flacCodec{})
+}

--- a/flac/register.go
+++ b/flac/register.go
@@ -1,3 +1,6 @@
+// Copyright 2018 The ZikiChombo Authors. All rights reserved.  Use of this source
+// code is governed by a license that can be found in the License file.
+
 package flac
 
 import (


### PR DESCRIPTION
PR to serve as an example for registration of a decoder.  It played a flac file (referenced but not included in the test)

